### PR TITLE
Record negatives in the element block

### DIFF
--- a/lib/synctexParser.js
+++ b/lib/synctexParser.js
@@ -38,7 +38,7 @@ var parseSyncTex = function (pdfsyncBody) {
   var closeverticalBlockPattern = /\]$/;
   var horizontalBlockPattern = /\(([0-9]+),([0-9]+):(-?[0-9]+),(-?[0-9]+):(-?[0-9]+),(-?[0-9]+),(-?[0-9]+)/;
   var closehorizontalBlockPattern = /\)$/;
-  var elementBlockPattern = /(.)([0-9]+),([0-9]+):-?([0-9]+),-?([0-9]+)(:?-?([0-9]+))?/;
+  var elementBlockPattern = /(.)([0-9]+),([0-9]+):(-?[0-9]+),(-?[0-9]+)(:?-?([0-9]+))?/;
 
   for (var i = 1; i < lineArray.length; i++) {
     var line = lineArray[i];


### PR DESCRIPTION
These were being left out of the regular expression groups.